### PR TITLE
Fix macOS compile error

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -239,8 +239,10 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         updatedDownloadsHandler?(downloads)
     }
 
+    #if os(iOS)
     func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
         
         return shouldAddStorePaymentHandler?(payment, product) ?? false
     }
+    #endif
 }


### PR DESCRIPTION
Fixes `Cannot override 'paymentQueue' which has been marked unavailable` error.